### PR TITLE
Abstract screen view

### DIFF
--- a/core/src/com/mygdx/game/Brainstorming.java
+++ b/core/src/com/mygdx/game/Brainstorming.java
@@ -1,33 +1,27 @@
 package com.mygdx.game;
 
 import com.badlogic.gdx.ApplicationAdapter;
+import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.mygdx.game.screens.GameScreenManager;
+import com.mygdx.game.screens.MenuScreen;
 
-public class Brainstorming extends ApplicationAdapter {
-	SpriteBatch batch;
-	Texture img;
-	
+public class Brainstorming extends Game {
+	GameScreenManager gsm;
+	public final static int WIDTH = 640;
+	public final static int HEIGHT = 360;
+
 	@Override
 	public void create () {
-		batch = new SpriteBatch();
-		img = new Texture("badlogic.jpg");
+		gsm = new GameScreenManager(this);
 	}
 
 	@Override
-	public void render () {
-		Gdx.gl.glClearColor(1, 0, 0, 1);
-		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-		batch.begin();
-		batch.draw(img, 0, 0);
-		batch.end();
-	}
-	
-	@Override
 	public void dispose () {
-		batch.dispose();
-		img.dispose();
+		gsm.dispose();
+		super.dispose();
 	}
 }

--- a/core/src/com/mygdx/game/screens/BaseScreen.java
+++ b/core/src/com/mygdx/game/screens/BaseScreen.java
@@ -1,0 +1,43 @@
+package com.mygdx.game.screens;
+
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.mygdx.game.Brainstorming;
+
+public abstract class BaseScreen implements Screen {
+
+    protected final GameScreenManager gsm;
+    protected Stage stage;
+
+    public BaseScreen(GameScreenManager gsm){
+        this.gsm = gsm;
+        this.stage = new Stage();
+    }
+
+    @Override
+    public void show(){
+        Gdx.input.setInputProcessor(stage);
+        resize(Brainstorming.WIDTH, Brainstorming.HEIGHT);
+    }
+
+    @Override
+    public void render(float delta){
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+    }
+
+    @Override
+    public void resize(int width, int height){
+        stage.getViewport().update(width, height, true);
+    }
+
+    @Override
+    public void dispose(){
+        stage.dispose();
+    }
+}
+
+
+

--- a/core/src/com/mygdx/game/screens/BaseScreen.java
+++ b/core/src/com/mygdx/game/screens/BaseScreen.java
@@ -17,8 +17,9 @@ import com.mygdx.game.Brainstorming;
  * Note to call the super method of
  * show: for the stage to process inputs,
  * dispose: to avoid rendering it when not in use.
- * render: call this first to clear the screen
- *         and avoid keeping data from last frame for optimalization
+ * render: call this first to clear the screen and avoid keeping data from last frame for optimalization
+ *
+ * Implementing the MVC pattern with Screens being part of the View component.
  */
 
 public abstract class BaseScreen implements Screen {

--- a/core/src/com/mygdx/game/screens/BaseScreen.java
+++ b/core/src/com/mygdx/game/screens/BaseScreen.java
@@ -7,6 +7,20 @@ import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.mygdx.game.Brainstorming;
 
+/**
+ * Basic abstract screen view implementing the Screen interface
+ *
+ * gsm: game screen manager to control the different screens
+ * stage: processing inputs and managing actors (2D Node Graph object)
+ * @see com.badlogic.gdx.scenes.scene2d.Actor
+ *
+ * Note to call the super method of
+ * show: for the stage to process inputs,
+ * dispose: to avoid rendering it when not in use.
+ * render: call this first to clear the screen
+ *         and avoid keeping data from last frame for optimalization
+ */
+
 public abstract class BaseScreen implements Screen {
 
     protected final GameScreenManager gsm;
@@ -25,7 +39,7 @@ public abstract class BaseScreen implements Screen {
 
     @Override
     public void render(float delta){
-        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT | GL20.GL_DEPTH_BUFFER_BIT);
     }
 
     @Override
@@ -38,6 +52,3 @@ public abstract class BaseScreen implements Screen {
         stage.dispose();
     }
 }
-
-
-

--- a/core/src/com/mygdx/game/screens/GameScreenManager.java
+++ b/core/src/com/mygdx/game/screens/GameScreenManager.java
@@ -1,0 +1,47 @@
+package com.mygdx.game.screens;
+
+
+import com.badlogic.gdx.graphics.Texture;
+import com.mygdx.game.Brainstorming;
+import java.util.HashMap;
+
+public class GameScreenManager {
+
+    private final Brainstorming game;
+    private HashMap<ScreenEnum, BaseScreen> gameScreens;
+
+    // Add to ScreenEnum as we extend more screen options
+    public enum ScreenEnum {
+        MENU,
+        GAME, // We probably want the game phases to extend from Game so this will need to apply to these situations
+        // SETTINGS,
+      }
+
+    public GameScreenManager(Brainstorming game){
+        this.game = game;
+        initGameScreens();
+        setScreen(ScreenEnum.MENU);
+    }
+
+
+    // Init screens in hash map
+    private void initGameScreens(){
+        this.gameScreens = new HashMap<>();
+        this.gameScreens.put(ScreenEnum.MENU, new MenuScreen(this));
+        this.gameScreens.put(ScreenEnum.GAME, new GameScreen(this, new Texture("gameScreen.jpg")));
+    }
+
+    public void setScreen(ScreenEnum nextScreen){
+        game.setScreen(gameScreens.get(nextScreen));
+    }
+
+    public void dispose(){
+        for(BaseScreen screen : gameScreens.values()){
+            if(screen != null ){
+                screen.dispose();
+          }
+      }
+    }
+
+
+}

--- a/core/src/com/mygdx/game/screens/GameScreenManager.java
+++ b/core/src/com/mygdx/game/screens/GameScreenManager.java
@@ -5,6 +5,13 @@ import com.badlogic.gdx.graphics.Texture;
 import com.mygdx.game.Brainstorming;
 import java.util.HashMap;
 
+/**
+ * Game screen manager to control and initialize the screens
+ *
+ * game: the Brainstorming game instance
+ * gameScreens: representing the game screens as a HasH Map with ScreenEnum-BaseScreen pair.
+ */
+
 public class GameScreenManager {
 
     private final Brainstorming game;
@@ -13,9 +20,16 @@ public class GameScreenManager {
     // Add to ScreenEnum as we extend more screen options
     public enum ScreenEnum {
         MENU,
-        GAME, // We probably want the game phases to extend from Game so this will need to apply to these situations
+        GAME, // We probably want the game phases to extend from Game so this will need to apply to these cases
         // SETTINGS,
       }
+
+    /**
+     * Initializing the screens in constructor
+     * Setting the menu screen as start screen
+     *
+     * @param game: Brainstorming game instance
+     */
 
     public GameScreenManager(Brainstorming game){
         this.game = game;
@@ -24,7 +38,6 @@ public class GameScreenManager {
     }
 
 
-    // Init screens in hash map
     private void initGameScreens(){
         this.gameScreens = new HashMap<>();
         this.gameScreens.put(ScreenEnum.MENU, new MenuScreen(this));

--- a/desktop/src/com/mygdx/game/desktop/DesktopLauncher.java
+++ b/desktop/src/com/mygdx/game/desktop/DesktopLauncher.java
@@ -8,5 +8,7 @@ public class DesktopLauncher {
 	public static void main (String[] arg) {
 		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
 		new LwjglApplication(new Brainstorming(), config);
+		config.width = Brainstorming.WIDTH;
+		config.height = Brainstorming.HEIGHT;
 	}
 }


### PR DESCRIPTION
# Background
Relevant to #11

# Solution
Implemented a simple abstract class for a base screen. This will init a `GameStateManager` and a `Stage` that uses its own SpriteBatch for drawing. I haven't researched the advantageous features it allows us but seems like it is frequently used. It implements the `Screen` interface which provide methods for a basic screen view.

`show()`: Assume that every screen will have a stage. In most cases they need to process inputs and this will initalize the processor. Also resize the stage to fit the default screen width and height. 

`dispose()`: Dispose the stage after the screen is not used. 
 
Created also a `GameScreenManager` for managing screens instead of having the logic in the `Brainstorming` class. This can be discussed whether it is the best solution. 


